### PR TITLE
Add responsive weather card with container queries

### DIFF
--- a/public/assets/ic_raindrop.svg
+++ b/public/assets/ic_raindrop.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor">
+  <path d="M32 8C28 16 20 24 20 34a12 12 0 0024 0c0-10-8-18-12-26z" />
+</svg>

--- a/public/assets/ic_weather_partly_cloudy.svg
+++ b/public/assets/ic_weather_partly_cloudy.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor">
+  <circle cx="20" cy="20" r="10" />
+  <circle cx="28" cy="40" r="12" />
+  <circle cx="44" cy="40" r="12" />
+  <rect x="28" y="40" width="16" height="12" />
+</svg>

--- a/public/assets/ic_weather_partly_cloudy_rain.svg
+++ b/public/assets/ic_weather_partly_cloudy_rain.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <circle cx="20" cy="20" r="10" />
+  <circle cx="28" cy="40" r="12" />
+  <circle cx="44" cy="40" r="12" />
+  <rect x="28" y="40" width="16" height="12" />
+  <line x1="24" y1="52" x2="24" y2="60" />
+  <line x1="36" y1="52" x2="36" y2="60" />
+  <line x1="48" y1="52" x2="48" y2="60" />
+</svg>

--- a/public/assets/ic_weather_rainy.svg
+++ b/public/assets/ic_weather_rainy.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <circle cx="28" cy="36" r="12" />
+  <circle cx="44" cy="36" r="12" />
+  <rect x="28" y="36" width="16" height="12" />
+  <line x1="24" y1="52" x2="24" y2="60" />
+  <line x1="36" y1="52" x2="36" y2="60" />
+  <line x1="48" y1="52" x2="48" y2="60" />
+</svg>

--- a/public/assets/ic_weather_sunny.svg
+++ b/public/assets/ic_weather_sunny.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <circle cx="32" cy="32" r="12" fill="currentColor" stroke="none"/>
+  <line x1="32" y1="4" x2="32" y2="12"/>
+  <line x1="32" y1="52" x2="32" y2="60"/>
+  <line x1="4" y1="32" x2="12" y2="32"/>
+  <line x1="52" y1="32" x2="60" y2="32"/>
+  <line x1="11" y1="11" x2="17" y2="17"/>
+  <line x1="47" y1="47" x2="53" y2="53"/>
+  <line x1="11" y1="53" x2="17" y2="47"/>
+  <line x1="47" y1="17" x2="53" y2="11"/>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ function App() {
   return (
     <div className="h-screen flex items-center justify-center">
       <div className="resize overflow-auto border p-4 min-w-[150px] min-h-[150px]">
-        <WeatherCard weather={SAMPLE_WEATHER} />
+        <WeatherCard data={SAMPLE_WEATHER} />
       </div>
     </div>
   );

--- a/src/components/WeatherCard.tsx
+++ b/src/components/WeatherCard.tsx
@@ -1,22 +1,81 @@
-import { MAP, WeatherType } from '../data/weather';
+import {
+  MAP,
+  WeatherType,
+  HourlyType,
+  DailyType,
+} from '../data/weather';
 
 interface Props {
-  weather: WeatherType;
+  data: WeatherType;
 }
 
-export default function WeatherCard({ weather }: Props) {
-  const info = MAP[weather.condition];
+function formatHour(time: number) {
+  const hour = time <= 12 ? time : time - 12;
+  const ampm = time < 12 ? 'AM' : 'PM';
+  return `${hour} ${ampm}`;
+}
+
+export default function WeatherCard({ data }: Props) {
+  const info = MAP[data.now.condition];
   return (
-    <div className="@container p-4 border rounded max-w-full">
-      <div className="flex flex-col items-center gap-2 @column:flex-col @row:flex-row">
+    <div className="@container bg-blue-500 text-white rounded p-4 flex flex-col gap-4 w-full h-full">
+      {/* Location */}
+      <p className="hidden @sm:block">{data.where}</p>
+
+      {/* Current conditions */}
+      <div className="flex items-center justify-center gap-4 @sm:flex-col @md:flex-row @md:justify-start">
         <img src={info.icon} alt={info.label} className="w-16 h-16" />
-        <div className="text-center @row:text-left">
-          <p className="font-semibold text-xl @tiny:text-sm">
-            {weather.temperature}&deg;C
+        <div className="text-center @md:text-left">
+          <p className="text-4xl font-semibold">{data.now.current}&deg;</p>
+          <p className="hidden @sm:block text-sm">
+            H {data.now.high}&deg; L {data.now.low}&deg;
           </p>
-          <p className="capitalize hidden @column:block">{info.label}</p>
+          <p className="hidden @sm:block capitalize">{info.label}</p>
         </div>
+      </div>
+
+      {/* Hourly forecast */}
+      <div className="hidden @md:flex gap-4 justify-center">
+        {data.hourly.map((hour: HourlyType) => (
+          <div key={hour.time} className="flex flex-col items-center gap-1">
+            <span className="text-sm">{formatHour(hour.time)}</span>
+            <img
+              src={MAP[hour.condition].icon}
+              alt=""
+              className="w-6 h-6"
+            />
+            <span className="text-sm">{hour.temp}&deg;</span>
+            <div className="flex items-center gap-1">
+              <img src="/assets/ic_raindrop.svg" alt="" className="w-3 h-3" />
+              <span className="text-sm">{hour.rain}%</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Daily forecast */}
+      <div className="hidden @lg:flex flex-col gap-2">
+        {data.daily.map((day: DailyType) => (
+          <div key={day.date} className="flex justify-between">
+            <span className="basis-28 text-sm">{day.date}</span>
+            <div className="flex items-center gap-2 w-24">
+              <img
+                src={MAP[day.condition].icon}
+                alt=""
+                className="w-6 h-6"
+              />
+              <span className="text-sm">
+                {day.high}&deg; / {day.low}&deg;
+              </span>
+            </div>
+            <div className="flex items-center gap-1 w-12">
+              <img src="/assets/ic_raindrop.svg" alt="" className="w-3 h-3" />
+              <span className="text-sm">{day.rain}%</span>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );
 }
+

--- a/src/components/WeatherCard.tsx
+++ b/src/components/WeatherCard.tsx
@@ -18,59 +18,59 @@ function formatHour(time: number) {
 export default function WeatherCard({ data }: Props) {
   const info = MAP[data.now.condition];
   return (
-    <div className="@container bg-blue-500 text-white rounded p-4 flex flex-col gap-4 w-full h-full">
+    <div className="@container bg-blue-500 text-white rounded p-[2cqmin] flex flex-col gap-[2cqmin] w-full h-full">
       {/* Location */}
-      <p className="hidden @sm:block">{data.where}</p>
+      <p className="hidden @[400px]:block text-[3cqw]">{data.where}</p>
 
       {/* Current conditions */}
-      <div className="flex items-center justify-center gap-4 @sm:flex-col @md:flex-row @md:justify-start">
-        <img src={info.icon} alt={info.label} className="w-16 h-16" />
-        <div className="text-center @md:text-left">
-          <p className="text-4xl font-semibold">{data.now.current}&deg;</p>
-          <p className="hidden @sm:block text-sm">
+      <div className="flex items-center justify-center gap-[2cqmin] @[400px]:flex-col @[700px]:flex-row @[700px]:justify-start">
+        <img src={info.icon} alt={info.label} className="w-[15cqw] h-[15cqw]" />
+        <div className="text-center @[700px]:text-left">
+          <p className="text-[9cqw] font-semibold">{data.now.current}&deg;</p>
+          <p className="hidden @[400px]:block text-[3cqw]">
             H {data.now.high}&deg; L {data.now.low}&deg;
           </p>
-          <p className="hidden @sm:block capitalize">{info.label}</p>
+          <p className="hidden @[400px]:block capitalize text-[3cqw]">{info.label}</p>
         </div>
       </div>
 
       {/* Hourly forecast */}
-      <div className="hidden @md:flex gap-4 justify-center">
+      <div className="hidden @[700px]:flex gap-[2cqmin] justify-center">
         {data.hourly.map((hour: HourlyType) => (
-          <div key={hour.time} className="flex flex-col items-center gap-1">
-            <span className="text-sm">{formatHour(hour.time)}</span>
+          <div key={hour.time} className="flex flex-col items-center gap-[1cqw]">
+            <span className="text-[3cqw]">{formatHour(hour.time)}</span>
             <img
               src={MAP[hour.condition].icon}
               alt=""
-              className="w-6 h-6"
+              className="w-[6cqw] h-[6cqw]"
             />
-            <span className="text-sm">{hour.temp}&deg;</span>
-            <div className="flex items-center gap-1">
-              <img src="/assets/ic_raindrop.svg" alt="" className="w-3 h-3" />
-              <span className="text-sm">{hour.rain}%</span>
+            <span className="text-[3cqw]">{hour.temp}&deg;</span>
+            <div className="flex items-center gap-[1cqw]">
+              <img src="/assets/ic_raindrop.svg" alt="" className="w-[3cqw] h-[3cqw]" />
+              <span className="text-[3cqw]">{hour.rain}%</span>
             </div>
           </div>
         ))}
       </div>
 
       {/* Daily forecast */}
-      <div className="hidden @lg:flex flex-col gap-2">
+      <div className="hidden @[1000px]:flex flex-col gap-[2cqmin]">
         {data.daily.map((day: DailyType) => (
           <div key={day.date} className="flex justify-between">
-            <span className="basis-28 text-sm">{day.date}</span>
-            <div className="flex items-center gap-2 w-24">
+            <span className="basis-[30cqw] text-[3cqw]">{day.date}</span>
+            <div className="flex items-center gap-[2cqw] w-[25cqw]">
               <img
                 src={MAP[day.condition].icon}
                 alt=""
-                className="w-6 h-6"
+                className="w-[6cqw] h-[6cqw]"
               />
-              <span className="text-sm">
+              <span className="text-[3cqw]">
                 {day.high}&deg; / {day.low}&deg;
               </span>
             </div>
-            <div className="flex items-center gap-1 w-12">
-              <img src="/assets/ic_raindrop.svg" alt="" className="w-3 h-3" />
-              <span className="text-sm">{day.rain}%</span>
+            <div className="flex items-center gap-[1cqw] w-[15cqw]">
+              <img src="/assets/ic_raindrop.svg" alt="" className="w-[3cqw] h-[3cqw]" />
+              <span className="text-[3cqw]">{day.rain}%</span>
             </div>
           </div>
         ))}

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -1,19 +1,79 @@
-export const CONDITIONS = ['sunny', 'cloudy', 'rain'] as const;
+export type CONDITIONS =
+  | 'PCLOUD_RAIN'
+  | 'PCLOUD'
+  | 'RAINY'
+  | 'SUNNY';
 
-export const MAP = {
-  sunny: { label: 'Sunny', icon: '/assets/sun.svg' },
-  cloudy: { label: 'Cloudy', icon: '/assets/cloud.svg' },
-  rain: { label: 'Rainy', icon: '/assets/rain.svg' },
-} as const;
-
-export type WeatherCondition = (typeof CONDITIONS)[number];
-
-export type WeatherType = {
-  condition: WeatherCondition;
-  temperature: number;
+export const MAP: Record<CONDITIONS, { label: string; icon: string }> = {
+  PCLOUD_RAIN: {
+    label: 'Partly cloudy w/Rain',
+    icon: '/assets/ic_weather_partly_cloudy_rain.svg',
+  },
+  PCLOUD: {
+    label: 'Partly cloudy',
+    icon: '/assets/ic_weather_partly_cloudy.svg',
+  },
+  RAINY: {
+    label: 'Rainy',
+    icon: '/assets/ic_weather_rainy.svg',
+  },
+  SUNNY: {
+    label: 'Sunny',
+    icon: '/assets/ic_weather_sunny.svg',
+  },
 };
+
+export interface NowType {
+  current: number;
+  condition: CONDITIONS;
+  high: number;
+  low: number;
+}
+
+export interface HourlyType {
+  time: number;
+  temp: number;
+  condition: CONDITIONS;
+  rain: number;
+}
+
+export interface DailyType {
+  date: string;
+  high: number;
+  low: number;
+  condition: CONDITIONS;
+  rain: number;
+}
+
+export interface WeatherType {
+  where: string;
+  now: NowType;
+  hourly: HourlyType[];
+  daily: DailyType[];
+}
 
 export const SAMPLE_WEATHER: WeatherType = {
-  condition: 'sunny',
-  temperature: 72,
+  where: 'Seattle',
+  now: {
+    current: 74,
+    condition: 'PCLOUD',
+    high: 76,
+    low: 68,
+  },
+  hourly: [
+    { time: 16, temp: 78, condition: 'SUNNY', rain: 0 },
+    { time: 17, temp: 76, condition: 'SUNNY', rain: 0 },
+    { time: 18, temp: 72, condition: 'RAINY', rain: 0 },
+    { time: 19, temp: 73, condition: 'PCLOUD', rain: 0 },
+    { time: 20, temp: 73, condition: 'PCLOUD', rain: 0 },
+    { time: 21, temp: 72, condition: 'PCLOUD_RAIN', rain: 0 },
+  ],
+  daily: [
+    { date: 'Wed, 5/21', high: 68, low: 58, condition: 'PCLOUD', rain: 100 },
+    { date: 'Thurs, 5/21', high: 62, low: 52, condition: 'PCLOUD', rain: 20 },
+    { date: 'Fri, 5/23', high: 68, low: 56, condition: 'PCLOUD', rain: 0 },
+    { date: 'Sat, 5/24', high: 68, low: 56, condition: 'PCLOUD', rain: 20 },
+    { date: 'Sun, 5/25', high: 68, low: 56, condition: 'PCLOUD', rain: 20 },
+  ],
 };
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,12 +2,6 @@
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    screens: {
-      tiny: '0px',
-      sm: '400px',
-      md: '700px',
-      lg: '1000px',
-    },
     extend: {},
   },
   plugins: [require('@tailwindcss/container-queries')],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,8 +4,9 @@ export default {
   theme: {
     screens: {
       tiny: '0px',
-      column: '400px',
-      row: '700px',
+      sm: '400px',
+      md: '700px',
+      lg: '1000px',
     },
     extend: {},
   },


### PR DESCRIPTION
## Summary
- replace static weather card with responsive layout using Tailwind container queries
- expand weather data to include current, hourly, and daily forecasts
- add SVG assets for multiple weather conditions and raindrop icon
- define container query breakpoints in Tailwind config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b9d7ffae9c83298fe3418fae35d32e