### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deploy
+        uses: actions/deploy-pages@v4
+

--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ Sample React + Tailwind project demonstrating container queries.
 npm install
 npm run dev
 ```
+
+## Deployment
+
+This project deploys to GitHub Pages. The site is built and published automatically
+when changes are pushed to the `main` branch. After the workflow runs, the site will
+be available at `https://<your-username>.github.io/weather-card/`.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,4 +3,5 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: '/weather-card/',
 });


### PR DESCRIPTION
## Summary
- configure Vite base path for GitHub Pages
- add GitHub Actions workflow to build and deploy
- document GitHub Pages deployment in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9ee705cdc8329a0b850500a661ddd