### PR TITLE
Fix GitHub Pages asset paths

### DIFF
--- a/src/components/WeatherCard.tsx
+++ b/src/components/WeatherCard.tsx
@@ -4,6 +4,7 @@ import {
   HourlyType,
   DailyType,
 } from '../data/weather';
+import raindropIcon from '/assets/ic_raindrop.svg';
 
 interface Props {
   data: WeatherType;
@@ -20,22 +21,22 @@ export default function WeatherCard({ data }: Props) {
   return (
     <div className="@container bg-blue-500 text-white rounded p-[2cqmin] flex flex-col gap-[2cqmin] w-full h-full">
       {/* Location */}
-      <p className="hidden @[400px]:block text-[3cqw]">{data.where}</p>
+      <p className="hidden @[25rem]:block text-[3cqw]">{data.where}</p>
 
       {/* Current conditions */}
-      <div className="flex items-center justify-center gap-[2cqmin] @[400px]:flex-col @[700px]:flex-row @[700px]:justify-start">
+      <div className="flex items-center justify-center gap-[2cqmin] @[25rem]:flex-col @md:flex-row @md:justify-start">
         <img src={info.icon} alt={info.label} className="w-[15cqw] h-[15cqw]" />
-        <div className="text-center @[700px]:text-left">
+        <div className="text-center @md:text-left">
           <p className="text-[9cqw] font-semibold">{data.now.current}&deg;</p>
-          <p className="hidden @[400px]:block text-[3cqw]">
+          <p className="hidden @[25rem]:block text-[3cqw]">
             H {data.now.high}&deg; L {data.now.low}&deg;
           </p>
-          <p className="hidden @[400px]:block capitalize text-[3cqw]">{info.label}</p>
+          <p className="hidden @[25rem]:block capitalize text-[3cqw]">{info.label}</p>
         </div>
       </div>
 
       {/* Hourly forecast */}
-      <div className="hidden @[700px]:flex gap-[2cqmin] justify-center">
+      <div className="hidden @md:flex gap-[2cqmin] justify-center">
         {data.hourly.map((hour: HourlyType) => (
           <div key={hour.time} className="flex flex-col items-center gap-[1cqw]">
             <span className="text-[3cqw]">{formatHour(hour.time)}</span>
@@ -45,16 +46,16 @@ export default function WeatherCard({ data }: Props) {
               className="w-[6cqw] h-[6cqw]"
             />
             <span className="text-[3cqw]">{hour.temp}&deg;</span>
-            <div className="flex items-center gap-[1cqw]">
-              <img src="/assets/ic_raindrop.svg" alt="" className="w-[3cqw] h-[3cqw]" />
-              <span className="text-[3cqw]">{hour.rain}%</span>
-            </div>
+              <div className="flex items-center gap-[1cqw]">
+                <img src={raindropIcon} alt="" className="w-[3cqw] h-[3cqw]" />
+                <span className="text-[3cqw]">{hour.rain}%</span>
+              </div>
           </div>
         ))}
       </div>
 
       {/* Daily forecast */}
-      <div className="hidden @[1000px]:flex flex-col gap-[2cqmin]">
+      <div className="hidden @lg:flex flex-col gap-[2cqmin]">
         {data.daily.map((day: DailyType) => (
           <div key={day.date} className="flex justify-between">
             <span className="basis-[30cqw] text-[3cqw]">{day.date}</span>
@@ -69,7 +70,7 @@ export default function WeatherCard({ data }: Props) {
               </span>
             </div>
             <div className="flex items-center gap-[1cqw] w-[15cqw]">
-              <img src="/assets/ic_raindrop.svg" alt="" className="w-[3cqw] h-[3cqw]" />
+              <img src={raindropIcon} alt="" className="w-[3cqw] h-[3cqw]" />
               <span className="text-[3cqw]">{day.rain}%</span>
             </div>
           </div>

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -1,3 +1,8 @@
+import partlyCloudyRainIcon from '/assets/ic_weather_partly_cloudy_rain.svg';
+import partlyCloudyIcon from '/assets/ic_weather_partly_cloudy.svg';
+import rainyIcon from '/assets/ic_weather_rainy.svg';
+import sunnyIcon from '/assets/ic_weather_sunny.svg';
+
 export type CONDITIONS =
   | 'PCLOUD_RAIN'
   | 'PCLOUD'
@@ -7,19 +12,19 @@ export type CONDITIONS =
 export const MAP: Record<CONDITIONS, { label: string; icon: string }> = {
   PCLOUD_RAIN: {
     label: 'Partly cloudy w/Rain',
-    icon: '/assets/ic_weather_partly_cloudy_rain.svg',
+    icon: partlyCloudyRainIcon,
   },
   PCLOUD: {
     label: 'Partly cloudy',
-    icon: '/assets/ic_weather_partly_cloudy.svg',
+    icon: partlyCloudyIcon,
   },
   RAINY: {
     label: 'Rainy',
-    icon: '/assets/ic_weather_rainy.svg',
+    icon: rainyIcon,
   },
   SUNNY: {
     label: 'Sunny',
-    icon: '/assets/ic_weather_sunny.svg',
+    icon: sunnyIcon,
   },
 };
 


### PR DESCRIPTION
## Summary
- import weather icons and raindrop icon instead of using root paths so built site references `/weather-card/assets/`
- replace pixel-based container queries with Tailwind breakpoints and rem-based threshold

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9f443045c8329a62ab06d0c170cb6